### PR TITLE
Update dependency to PyCryptodome

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ package_dir =
     = src
 packages = find:
 python_requires = >=3.6
-install_requires = pycrypto
+install_requires = pycryptodome
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
PyCrypto is a very old library and doesn't build properly in many environments (eg. Windows). PyCryptodome is a newer and actively maintained fork that should be a drop-in replacement